### PR TITLE
Fixed layer profile offset calculation

### DIFF
--- a/boards/shields/nice_view_gem/widgets/profile.c
+++ b/boards/shields/nice_view_gem/widgets/profile.c
@@ -14,7 +14,7 @@ static void draw_active_profile(lv_obj_t *canvas, const struct status_state *sta
     lv_draw_rect_dsc_t rect_white_dsc;
     init_rect_dsc(&rect_white_dsc, LVGL_FOREGROUND);
 
-    int offset = state->active_profile_index * 7;
+    int offset = state->layer_index * 7;
 
     lv_canvas_draw_rect(canvas, 18 + offset, 129 + BUFFER_OFFSET_BOTTOM, 3, 3, &rect_white_dsc);
 }


### PR DESCRIPTION
The offset calculation is currently using the `active_profile_index` which is a member of the `status_state` struct that never gets updated. This causes the layer dot to never change position when the display is redrawn in the `screen.c` file. The correct member to use in the offset calculation is `layer_index` because this member is the one that is updated whenever the `zmk_layer_state_changed` event fires.