### PR TITLE
Add option to override specific frame when animation is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Modify the behavior of this shield by adjusting these options in your personal c
 | `CONFIG_NICE_VIEW_GEM_WPM_FIXED_RANGE_MAX` | int  | You can adjust the maximum value of the fixed range to align with your current goal.                                                                                                                                                                              | 100     |
 | `CONFIG_NICE_VIEW_GEM_ANIMATION`           | bool | If you find the animation distracting (or want to save on battery usage), you can turn it off by setting this option to `n`. It will instead pick a random frame of the animation every time you restart your keyboard.                                           | y       |
 | `CONFIG_NICE_VIEW_GEM_ANIMATION_MS`        | int  | Alternatively, you can slow down the animation. A high value, such as 96000, slows the animation considerably, showing the next frame every couple of seconds. The animation consists of 16 frames, and the default value of 960 milliseconds plays it at 60 fps. | 960     |
+| `CONFIG_NICE_VIEW_GEM_ANIMATION_FRAME` | int | If you choose to keep the animation frozen, you can set this index to a specific crystal frame (frames 1-16) you want to have displayed | 0 |
 
 ## Credits
 

--- a/boards/shields/nice_view_gem/Kconfig.defconfig
+++ b/boards/shields/nice_view_gem/Kconfig.defconfig
@@ -39,6 +39,10 @@ config NICE_VIEW_GEM_ANIMATION
     bool "Enable animation on peripheral"
     default y
 
+config NICE_VIEW_GEM_ANIMATION_FRAME
+    int "Frame index (out of 16) to use if animation is disabled"
+    default 0
+
 config NICE_VIEW_GEM_ANIMATION_MS
     int "Animation length in milliseconds"
     default 960

--- a/boards/shields/nice_view_gem/widgets/animation.c
+++ b/boards/shields/nice_view_gem/widgets/animation.c
@@ -40,8 +40,10 @@ void draw_animation(lv_obj_t *canvas) {
     int length = sizeof(anim_imgs) / sizeof(anim_imgs[0]);
     srand(k_uptime_get_32());
     int random_index = rand() % length;
+    int configured_index = (CONFIG_NICE_VIEW_GEM_ANIMATION_FRAME - 1) % length;
+    int anim_imgs_index = CONFIG_NICE_VIEW_GEM_ANIMATION_FRAME > 0 ? configured_index : random_index;
 
-    lv_img_set_src(art, anim_imgs[random_index]);
+    lv_img_set_src(art, anim_imgs[anim_imgs_index]);
 #endif
 
     lv_obj_align(art, LV_ALIGN_TOP_LEFT, 36, 0);


### PR DESCRIPTION
### Change

- Allow override of random frame chosen when `CONFIG_NICE_VIEW_GEM_ANIMATION` is set to `n`.

### Context

I wanted to set to a specific frame for my eyelash corne custom screen. Apologies my coding style is probably not up to your standards in the repo, open to feedback or if you don't think this belongs. 


Otherwise, a big thanks to building this love the customization and appreciate the time you spent building this!

### Testing

I didn't manually test the integer overflow cases, but am happy to do so.

1. Switching to custom fork: https://github.com/camerondurham/zmk-new_corne/commit/e5d1ae5cb572d59e2512cc3ee02929021d8ff5ed
1. Flashed keyboard setting frame explicitly to the 5th `crystal_05` image
 
<img width="557" alt="image" src="https://github.com/user-attachments/assets/e9f30fd8-b7ea-46bc-bc9b-dbf8c6ddaa0a" />

