### PR TITLE
attempt to fix the layer status

### DIFF
--- a/boards/shields/nice_view_gem/widgets/layer.c
+++ b/boards/shields/nice_view_gem/widgets/layer.c
@@ -8,8 +8,8 @@ void draw_layer_status(lv_obj_t *canvas, const struct status_state *state) {
 
     char text[10] = {};
 
-    if (state->layer_label == NULL) {
-        sprintf(text, "Layer %i", state->layer_index);
+    if (state->layer_label == NULL || strlen(state->layer_label) == 0) {
+        sprintf(text, "L %i", state->layer_index);
     } else {
         strncpy(text, state->layer_label, 9);
         to_uppercase(text);

--- a/boards/shields/nice_view_gem/widgets/screen.c
+++ b/boards/shields/nice_view_gem/widgets/screen.c
@@ -126,7 +126,7 @@ static struct layer_status_state layer_status_get_state(const zmk_event_t *eh) {
 }
 
 ZMK_DISPLAY_WIDGET_LISTENER(widget_layer_status, struct layer_status_state, layer_status_update_cb,
-                            layer_status_get_state)
+                            layer_status_get_state);
 
 ZMK_SUBSCRIPTION(widget_layer_status, zmk_layer_state_changed);
 


### PR DESCRIPTION
Resolves https://github.com/M165437/nice-view-gem/issues/11
- Fix the issue with the layer status not showing when the label is empty instead of null
- Not sure why the layer status is also not showing when: the label is empty, and the prefix is `Layer`, but showing when the prefix is only `L`