### PR TITLE
fix: rename zmk_endpoints_selected() to zmk_endpoint_get_selected()

### DIFF
--- a/boards/shields/nice_view_gem/widgets/screen.c
+++ b/boards/shields/nice_view_gem/widgets/screen.c
@@ -152,7 +152,7 @@ static void output_status_update_cb(struct output_status_state state) {
 
 static struct output_status_state output_status_get_state(const zmk_event_t *_eh) {
     return (struct output_status_state){
-        .selected_endpoint = zmk_endpoints_selected(),
+        .selected_endpoint = zmk_endpoint_get_selected(),
         .active_profile_index = zmk_ble_active_profile_index(),
         .active_profile_connected = zmk_ble_active_profile_is_connected(),
         .active_profile_bonded = !zmk_ble_active_profile_is_open(),


### PR DESCRIPTION
## Summary

- Fixes build failure when using nice-view-gem with ZMK `main` branch (Zephyr 4.1+)
- `zmk_endpoints_selected()` was renamed to `zmk_endpoint_get_selected()` in ZMK `main` — this one-line change updates the call in `screen.c` to match

Without this fix, the left (central) half fails to link:

```
screen.c:155: undefined reference to `zmk_endpoints_selected'
```